### PR TITLE
SGS-6: Removing programs display control

### DIFF
--- a/configuration/openmrs/apps/clinical/dashboard.json
+++ b/configuration/openmrs/apps/clinical/dashboard.json
@@ -81,11 +81,6 @@
                 "showDetailsButton":true,
                 "displayOrder":5
             },
-            "programs":{
-                "translationKey":"DASHBOARD_TITLE_PROGRAMS_KEY",
-                "type":"programs",
-                "displayOrder":6
-            },
             "radiologyOrders":{
                 "orderType":"Radiology Order",
                 "type":"ordersControl",


### PR DESCRIPTION
I removed the programs json tag from the dashboard.json file to make this work.